### PR TITLE
Fix: Empty actual array will not trigger mismatch

### DIFF
--- a/lib/rspec/resembles_json_matchers/resembles_any_of_matcher.rb
+++ b/lib/rspec/resembles_json_matchers/resembles_any_of_matcher.rb
@@ -13,7 +13,7 @@ module RSpec::ResemblesJsonMatchers
     end
 
     def matches?(actual)
-      Array.wrap(actual).flatten.all? do |a|
+      matches_arity?(actual) && Array.wrap(actual).flatten.all? do |a|
         expected_matchers.any? { |m| m.matches? a }
       end
     end
@@ -56,6 +56,11 @@ module RSpec::ResemblesJsonMatchers
     def failure_messages
     end
 
+    private
+
+    def matches_arity?(actual)
+      Array.wrap(actual).empty? == expected_matchers.empty?
+    end
   end
 
 end

--- a/spec/matchers/resembles_any_of_matcher_spec.rb
+++ b/spec/matchers/resembles_any_of_matcher_spec.rb
@@ -22,7 +22,22 @@ RSpec.describe RSpec::ResemblesJsonMatchers::ResemblesAnyOfMatcher do
     let(:given) { [ 1, 2, "foo" ] }
     let(:matcher_candidates) { [ be_kind_of(Integer) ] }
 
+    specify {
+      expect(matcher.matches? given).to_not be_truthy
+    }
+  end
+
+  context "when given array is empty" do
+    let(:given) { [] }
+    let(:matcher_candidates) { ["foo"] }
+
     specify { expect(matcher.matches? given).to_not be_truthy }
+
+    context "and matchers are empty" do
+      let(:matcher_candidates) { [] }
+
+      specify { expect(matcher.matches? given).to be_truthy }
+    end
   end
 
   describe "#description" do


### PR DESCRIPTION
I believe I've found a bug when an empty array will not mismatch a non-empty matcher:

This will pass:

`expect({ "foo" => [] }).to resemble_json({ "foo" => [{ "id" => "bar" }]})`

The fix that I'm attempting is to check whether their emptiness matches in addition to all values.